### PR TITLE
Use parametres as strings to avoid conversion in PHP 5.3.3

### DIFF
--- a/config-core.php
+++ b/config-core.php
@@ -32,7 +32,7 @@ $arrSettings["zabbixApiUrl"] = "http://www.mozbx.net/zabbix/";
 
 /* Debug JSON requests: echo all sent & received data */
 $arrSettings["jsonDebug"] = true;
-$arrSettings["jsonDebug_path"] = "/home/mattias/Development/MoZBX/";
+$arrSettings["jsonDebug_path"] = "/tmp/mozbx/";
 
 /* How long should our cookies be valid? */
 $arrSettings["cookieExpire"] = time() + 60 * 60 * 7;

--- a/graph.php
+++ b/graph.php
@@ -27,10 +27,10 @@
 
     require_once("template/header.php");
 
-	$zabbixGraphId = (int) $_GET['graphid'];
-    $zabbixGraphPeriod = (int) $_GET['period'];
-    $zabbixHostId = (int) $_GET['hostid'];
-    $zabbixHostGroupId = (int) $_GET['groupid'];
+	$zabbixGraphId = (string) $_GET['graphid'];
+    $zabbixGraphPeriod = (string) $_GET['period'];
+    $zabbixHostId = (string) $_GET['hostid'];
+    $zabbixHostGroupId = (string) $_GET['groupid'];
     $zabbixHostGroupName = (string) urldecode($_GET['groupname']);
     $zabbixHostName = (string) urldecode($_GET['hostname']);
 
@@ -85,27 +85,27 @@
         <img src="graph_img.php?graphid=<?php echo $zabbixGraphId?>&period=<?php echo $zabbixGraphPeriod?>" width="500" />
 
         <ul class="nav nav-pills nav-stacked">
-            <li<?php echo ((int) $zabbixGraphPeriod == 3600) ? ' class="active"' : ''; ?>>
+            <li<?php echo ((string) $zabbixGraphPeriod == 3600) ? ' class="active"' : ''; ?>>
                 <a href="graph.php?graphid=<?php echo $zabbixGraphId?>&period=3600&<?php echo $urlParameters; ?>">
                     <i class="icon-time"></i> 1 hour
                 </a>
             </li>
-            <li<?php echo ((int) $zabbixGraphPeriod == 7200) ? ' class="active"' : ''; ?>>
+            <li<?php echo ((string) $zabbixGraphPeriod == 7200) ? ' class="active"' : ''; ?>>
                 <a href="graph.php?graphid=<?php echo $zabbixGraphId?>&period=7200&<?php echo $urlParameters; ?>">
                     <i class="icon-time"></i> 2 hours
                 </a>
             </li>
-            <li<?php echo ((int) $zabbixGraphPeriod == 10800) ? ' class="active"' : ''; ?>>
+            <li<?php echo ((string) $zabbixGraphPeriod == 10800) ? ' class="active"' : ''; ?>>
                 <a href="graph.php?graphid=<?php echo $zabbixGraphId?>&period=10800&<?php echo $urlParameters; ?>">
                     <i class="icon-time"></i> 3 hours
                 </a>
             </li>
-            <li<?php echo ((int) $zabbixGraphPeriod == 21600) ? ' class="active"' : ''; ?>>
+            <li<?php echo ((string) $zabbixGraphPeriod == 21600) ? ' class="active"' : ''; ?>>
                 <a href="graph.php?graphid=<?php echo $zabbixGraphId?>&period=21600&<?php echo $urlParameters; ?>">
                     <i class="icon-time"></i> 6 hours
                 </a>
             </li>
-            <li<?php echo ((int) $zabbixGraphPeriod == 43200) ? ' class="active"' : ''; ?>>
+            <li<?php echo ((string) $zabbixGraphPeriod == 43200) ? ' class="active"' : ''; ?>>
                 <a href="graph.php?graphid=<?php echo $zabbixGraphId?>&period=43200&<?php echo $urlParameters; ?>">
                     <i class="icon-time"></i> 12 hours
                 </a>

--- a/graph_img.php
+++ b/graph_img.php
@@ -25,8 +25,8 @@
 		exit();
 	}
 
-	$graphid = (int) $_GET['graphid'];
-    $graphperiod = (int) $_GET['period'];
+	$graphid = (string) $_GET['graphid'];
+    $graphperiod = (string) $_GET['period'];
 	
 	// Set correct header
 	header("Content-Type: image/jpg");

--- a/host.php
+++ b/host.php
@@ -26,8 +26,8 @@
 
     require_once("template/header.php");
 
-	$zabbixHostId = (int) $_GET['hostid'];
-    $zabbixHostGroupId = (int) $_GET['groupid'];
+	$zabbixHostId = (string) $_GET['hostid'];
+    $zabbixHostGroupId = (string) $_GET['groupid'];
     $zabbixHostGroupName = (string) urldecode($_GET['groupname']);
 	if ($zabbixHostId > 0) {
 		$host 		= $zabbix->getHostById($zabbixHostId);

--- a/hosts.php
+++ b/hosts.php
@@ -29,7 +29,7 @@
 
     require_once("template/header.php");
 
-	$zabbixHostgroupId = (int) $_GET['hostgroupid'];
+	$zabbixHostgroupId = (string) $_GET['hostgroupid'];
 	if ($zabbixHostgroupId > 0) {
 		$hostgroup 	= $zabbix->getHostgroupById($zabbixHostgroupId);
 		$hosts 		= $zabbix->getHostsByGroupId ($zabbixHostgroupId);

--- a/template/footer.php
+++ b/template/footer.php
@@ -7,7 +7,6 @@
 ?>
 <!-- Some basic usage tracking. Nice stats on browser agents etc. 
 So I know on which browser(s) to focus most -->
-<img src="http://www.mozbx.net/images/tracker.png" />
 <?php
     }
 

--- a/trigger_ack.php
+++ b/trigger_ack.php
@@ -47,7 +47,7 @@
     }
     
 	if ($ack_ok) {
-        header("Location: trigger_info.php?triggerid=". (int) $_POST['triggerid']);
+        header("Location: trigger_info.php?triggerid=". (string) $_POST['triggerid']);
         exit();
     } else {
         /* Something, somewhere, went terribly wrong */

--- a/trigger_info.php
+++ b/trigger_info.php
@@ -26,8 +26,8 @@
 
     require_once("template/header.php");
 
-	$zabbixTriggerId = (int) $_GET['triggerid'];
-    $zabbixHostId = (int) $_GET['hostid'];
+	$zabbixTriggerId = (string) $_GET['triggerid'];
+    $zabbixHostId = (string) $_GET['hostid'];
 	if ($zabbixTriggerId > 0 && $zabbixHostId > 0) {
         // Retrieve the trigger information
         $trigger = $zabbix->getTriggerByTriggerAndHostId($zabbixTriggerId, $zabbixHostId);


### PR DESCRIPTION
Use parametres as strings, because on PHP 5.3.3 they were converted to INT which caused any requests to Zabbix API to fail. Note: The diff also includes removing the tracker image and a change to config-core, at least the tracker image change shouldn't be committed to base.
