### PR TITLE
Add (optional) support for HTTP authentication

### DIFF
--- a/class_zabbix.php
+++ b/class_zabbix.php
@@ -44,7 +44,7 @@ class Zabbix
     private $zabbix_tmp_cookies = "";
     private $zabbix_url_graph = "";
     private $zabbix_url_index = "";
-
+    private $http_auth = false;
 
     /* ##########################################################
          ##
@@ -80,6 +80,7 @@ class Zabbix
         $this->json_debug = $arrSettings["jsonDebug"];
         $this->json_debug_path = $arrSettings["jsonDebug_path"];
         $this->curl_verbose = $arrSettings["curlVerbose"];
+        $this->http_auth = $arrSettings["useHttpAuth"];
     }
 
 
@@ -690,6 +691,11 @@ class Zabbix
 
         // Build our encoded JSON
         $json_data = $this->genericJSONPost($action, $parameters);
+
+        if ($this->http_auth) {
+            $curl_opts[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;
+            $curl_opts[CURLOPT_USERPWD] = $this->zabbix_username . ':' . $this->zabbix_password;
+        }
 
         $curl_opts[CURLOPT_VERBOSE] = $this->curl_verbose;
         $curl_opts[CURLOPT_HTTPHEADER] = $json_headers;

--- a/config-core.php
+++ b/config-core.php
@@ -16,6 +16,10 @@ $arrSettings["isHosted"] = true;
 /* Note: if you set this to false, everyone visiting this URL will have access !! */
 $arrSettings["promptCredentials"] = true;
 
+/* If set to true, provides HTTP basic auth credentials to cURL */
+/* Useful if your zabbix server is protected by HTTP Auth instead of, or in addition to form authentication */
+$arrSettings["useHttpAuth"] = false;
+
 /* Your Zabbix's server's hostname: used in the Zabbix Cookie Forging for retrieving graphs */
 /* This needs to match your server's hostname. Ie: http://zabbix.lab.mojah.be/zabbix/index.php */
 /* Would mean your zabbixHostname is 'zabbix.lab.mojah.be' (the FQDN) */


### PR DESCRIPTION
This change adds optional support for HTTP authentication when making requests to the zabbix host. This is useful if you have your zabbix installation protected by HTTP authentication and/or are using the zabbix HTTP auth pass-through authentication.

-dan
