### PR TITLE
Proposed fix for Issue 39 - Append "api_jsonrpc.php" to $this->zabbix_url in Zabbix class ctor

### DIFF
--- a/class_zabbix.php
+++ b/class_zabbix.php
@@ -69,7 +69,7 @@ class Zabbix
 
     public function __construct($arrSettings)
     {
-        $this->zabbix_url = $arrSettings["zabbixApiUrl"];
+        $this->zabbix_url = $arrSettings["zabbixApiUrl"] . "api_jsonrpc.php";
         $this->zabbix_hostname = $arrSettings["zabbixHostname"];
         $this->zabbix_username = $arrSettings["zabbixUsername"];
         $this->zabbix_password = $arrSettings["zabbixPassword"];


### PR DESCRIPTION
A minor change to address automatic login failure by appending "api_jsonrpc.php" to $this->zabbix_url in the Zabbix class constructor, this also makes it consistent with setting of similar URL variables in the constructor ($this->zabbix_url_chart and $this->zabbix_url_index)

See also: https://github.com/mattiasgeniar/MoZBX/issues/39
